### PR TITLE
palette: Fix import of colortrans

### DIFF
--- a/src/autopalette/palette.py
+++ b/src/autopalette/palette.py
@@ -4,7 +4,7 @@ from colour import Color
 
 from autopalette.colormatch import ColorPoint, ColorMatch, AnsiCodeType
 from autopalette.utils import parse_color, map_interval
-from colortrans import rgb2short, short2rgb
+from autopalette.colortrans import rgb2short, short2rgb
 
 
 class BasePalette(object):


### PR DESCRIPTION
This commit fixes the following import statement:

```
from autopalette import af
```

which raises the following error:

```
ModuleNotFoundError: No module named 'colortrans'
```

**Complete traceback**

```In [1]: from autopalette import af
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-24055e40400f> in <module>()
----> 1 from autopalette import af

~/github.com/autopalette/src/autopalette/__init__.py in <module>()
----> 1 from .palette import (
      2     AutoPalette,
      3     Gray4Palette,
      4     GameBoyGeenPalette,
      5     GameBoyChocolatePalette,

~/github.com/autopalette/src/autopalette/palette.py in <module>()
      5 from autopalette.colormatch import ColorPoint, ColorMatch, AnsiCodeType
      6 from autopalette.utils import parse_color, map_interval
----> 7 from colortrans import rgb2short, short2rgb
      8 
      9 

ModuleNotFoundError: No module named 'colortrans'
```

**Steps to reproduce (with Python3.6.5)**
```
$ virtualenv venv
$ source venv/bin/activate
$ python setup.py install
$ python
>>> from autocomplete import af
```